### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -95,9 +95,9 @@ First install `Build tools for Visual Studio 2019 <https://visualstudio.microsof
 
 .. note::
 
-    You only need build tools for Visual Studio 2019 and not Visual Studio 2019
+    You `do not` need to install Visual Studio 2019. You only need the **Build Tools for Visual Studio 2019**, under **All downloads** -> **Tools for Visual Studio 2019**.
 
-Then configure the build environment to build 64-bit Python.
+For 64-bit Python, configure the build environment by running the following commands in ``cmd`` console.
 
 .. code-block:: bat
 


### PR DESCRIPTION
### For the first change:

The  Build Tools for Visual Studio 2019 download button is hidden from the main page. According to the installation guideline from [scikit-learn](https://scikit-learn.org/stable/developers/advanced_installation.html#windows), I add the specific download path for the newbies, which could be more friendly.

### For the second change:

The following command can only be executed in `cmd`. I tried a lot and failed in PowerShell, and this could happen to others as well. 🤣 