### PR TITLE
bugfix: windows cache path not found error

### DIFF
--- a/wildboar/datasets/__init__.py
+++ b/wildboar/datasets/__init__.py
@@ -72,7 +72,7 @@ def _os_cache_path(dir):
     import platform
 
     if platform.system() == "Windows":
-        cache_dir = os.path.expandvars(r"%LOCALAPPDATA%\Caches")
+        cache_dir = os.path.expandvars(r"%LOCALAPPDATA%\cache")
         return os.path.join(cache_dir, dir)
     elif platform.system() == "Linux":
         cache_dir = os.environ.get("XDG_CACHE_HOME")


### PR DESCRIPTION
This bugfix is linked with issue #15 